### PR TITLE
Point the NUSPEC to the GitHub project site

### DIFF
--- a/src/SerilogMetrics/SerilogMetrics.nuspec
+++ b/src/SerilogMetrics/SerilogMetrics.nuspec
@@ -3,13 +3,13 @@
   <metadata>
     <id>SerilogMetrics</id>
     <version>$version$</version>
-    <authors>Serilog Contributors</authors>
+    <authors>SerilogMetrics Contributors</authors>
     <description>Provides utilities to facilitate metrics (timers, counters, gauges, meters, healthchecks) on top of Serilog.</description>
     <language>en-US</language>
-    <projectUrl>http://serilog.net</projectUrl>
+    <projectUrl>https://github.com/serilog-metrics/serilog-metrics</projectUrl>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
     <iconUrl>http://serilog.net/images/serilog-nuget.png</iconUrl>
-    <tags>serilog logging diagnostics timing measure</tags>
+    <tags>serilog metrics logging diagnostics timing measure</tags>
     <dependencies>
       <dependency id="Serilog" version="$version$" />
     </dependencies>


### PR DESCRIPTION
May be a better link location e.g. for issue tracking etc.
