### PR TITLE
Add support for rules based writing

### DIFF
--- a/src/SerilogMetrics.Samples.Console/Program.cs
+++ b/src/SerilogMetrics.Samples.Console/Program.cs
@@ -69,6 +69,15 @@ namespace SerilogMetrics.Samples.Console
 			counter.Increment();
 			counter.Decrement();
 
+
+            var counterFunc = logger.CountOperation("counter", "operation(s)", true, LogEventLevel.Debug, writeRule: (e, i) => (i % 5) == 0);
+
+		    for (var i = 0; i < 11; i++)
+		    {
+                counterFunc.Increment();
+		    }
+
+
 			System.Console.WriteLine("Press a key to exit.");
 			System.Console.ReadKey(true);
 		}

--- a/src/SerilogMetrics/LoggerExtensions.cs
+++ b/src/SerilogMetrics/LoggerExtensions.cs
@@ -155,6 +155,7 @@ namespace Serilog
         /// <param name="directWrite">Indicates if a change in the counter needs to be written to the log directly. By default enabled. When disabled, you need to explicitly call the Write() method to output the current value.</param>
         /// <param name="level">The level used to write the timing operation details to the log. By default this is the information level.</param>
         /// <param name="template">A message template describing the format used to write to the log.</param>
+        /// <param name="writeRule">Func to determine when to write to logs based on the result of the Func. First value is the current count. Second value is number of times Increment or Decrement has been called.</param>
         /// <returns></returns>
         public static ICounterMeasure CountOperation(
            this ILogger logger,
@@ -162,12 +163,13 @@ namespace Serilog
             string uom = "operation(s)",
             bool directWrite = true,
            LogEventLevel level = LogEventLevel.Information,
-           string template = DefaultCountTemplate)
+           string template = DefaultCountTemplate,
+            Func<long, long, bool> writeRule = null)
         {
             if (string.IsNullOrWhiteSpace(name))
                 throw new ArgumentNullException("name");
 
-            return new CounterMeasure(logger, name, uom, level, template, directWrite);
+            return new CounterMeasure(logger, name, uom, level, template, directWrite, writeRule);
         }
 
 		/// <summary>

--- a/src/SerilogMetrics/Measures/CounterMeasure.cs
+++ b/src/SerilogMetrics/Measures/CounterMeasure.cs
@@ -14,6 +14,7 @@
 
 using Serilog.Events;
 using Serilog;
+using System;
 
 namespace SerilogMetrics
 {

--- a/test/SerilogMetrics.Tests/CounterMeasureTests.cs
+++ b/test/SerilogMetrics.Tests/CounterMeasureTests.cs
@@ -109,6 +109,29 @@ namespace SerilogMetrics.Tests
 			check.Reset ();
 			Assert.AreEqual ("\"invocations\" count = 0 times", _eventSeen.RenderMessage ());
 		}
+
+	    [Test ()]
+	    public void CounterWritesWhenFuncReturnsTrue()
+	    {
+            var check = Log.Logger.CountOperation("invocations", "times", false, LogEventLevel.Debug, writeRule: (e, i) => (i % 2) == 0);
+
+	        var lastSeenMessage = "";
+
+	        var numberOfEventsEmitted = 0;
+
+            for (var i = 0; i < 20; i++)
+	        {
+	            check.Increment();
+
+	            if (_eventSeen != null && lastSeenMessage != _eventSeen.RenderMessage())
+	            {
+	                lastSeenMessage = _eventSeen.RenderMessage();
+	                numberOfEventsEmitted++;
+	            }
+	        }
+
+            Assert.AreEqual (10, numberOfEventsEmitted);
+	    }
 	}
 	
 }


### PR DESCRIPTION
When counting a large number of operations this generates a large number of logs. The ability to log based on a rule allows fine grained control over how often it writes.
